### PR TITLE
:pencil: Add Semantic UI install steps in doc

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -36,13 +36,23 @@ python manage.py migrate
 python manage.py runserver
 ```
 
-* Set up the frontend: 
+* Set up the frontend:
 
 ```bash
 cd frontend/
-npm install
+npm ci
+```
+This will build the project dependencies based off of the `package-lock.json`.
+
+[`Semantic UI`](https://react.semantic-ui.com/) has an interactive installer and may prompt you for input in the console. Choose the default options if prompted:
+1. Set-up Semantic UI: `Automatic (Use default locations and all components)`
+2. Is this your project folder?: Confirm it is the project folder and choose `Yes`
+3. Where should we put Semantic UI inside your project?: `semantic/`
+
+After the build completes:
+
+```bash
 npm start
 ```
 
 As you can see, both the frontend and backend are two separate entities. To access the backend API go to `localhost:8000`, but most of the time you'll be using the main app \(the frontend\) by going to `localhost:3000`.
-


### PR DESCRIPTION
Added Semantic UI install steps to the frontend setup documentation after running `npm ci`.

I wasn't sure the best way to walk through someone choosing options in the interactive installer. Hopefully this works. Let me know what you think. Thanks!