### PR TITLE
Restrict host access in production

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -19,6 +19,7 @@ load_dotenv()
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+HEROKU = '/app' in os.environ['HOME']
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
@@ -29,7 +30,10 @@ SECRET_KEY = 'mp=7%x4y3*b2*ehgc!*xslh*c9$$edf6bqdr6m9xx35=fb_zx%'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG')
 
-ALLOWED_HOSTS = ['.netlify.com', 'localhost', '127.0.0.1']
+if HEROKU:
+    ALLOWED_HOSTS = ['.netlify.com']
+else:
+    ALLOWED_HOSTS['localhost', '127.0.0.1']
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
@@ -154,6 +158,6 @@ IGDB_URL = 'https://api-v3.igdb.com/{endpoint}/'
 
 # Django Heroku
 
-if '/app' in os.environ['HOME']:
+if HEROKU:
     import django_heroku
     django_heroku.settings(locals())

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -33,7 +33,7 @@ DEBUG = os.getenv('DEBUG')
 if HEROKU:
     ALLOWED_HOSTS = ['.netlify.com']
 else:
-    ALLOWED_HOSTS['localhost', '127.0.0.1']
+    ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',


### PR DESCRIPTION
Create the `HEROKU` boolean variable to check if the current build is from production or not.

This allows us to be more versatile with the project's configuration.