### PR TITLE
Rating bars improvements

### DIFF
--- a/frontend/src/modules/profile/components/ratings/index.js
+++ b/frontend/src/modules/profile/components/ratings/index.js
@@ -1,8 +1,8 @@
 import React from "react";
-import "./styles.css";
-import { loadRatings } from "../../actions";
 import { connect } from "react-redux";
-import { Divider } from "semantic-ui-react";
+import { Divider, Popup } from "semantic-ui-react";
+import { loadRatings } from "../../actions";
+import "./styles.css";
 
 class Ratings extends React.Component {
   constructor(props) {
@@ -14,7 +14,7 @@ class Ratings extends React.Component {
   }
 
   componentWillMount() {
-    this.props.loadRatings(this.props.user_id);
+    this.props.loadRatings(this.props.userId);
   }
 
   processRatings = data => {
@@ -39,7 +39,6 @@ class Ratings extends React.Component {
       return (
         <React.Fragment>
           <Divider horizontal>Ratings</Divider>
-
           <div className="rating">
             <div
               className="rating-chart"
@@ -48,20 +47,30 @@ class Ratings extends React.Component {
               {chartData.map((val, i) => {
                 const percent = total ? val / total : 0; //calculate percent if total is non zero
                 return (
-                  <div
-                    className="rating-bar"
-                    key={"rating" + i}
-                    style={{
-                      height: (percent * this.props.height) +1,
-                      width: this.props.width / chartData.length
-                    }}
+                  <Popup
+                    content={`${i + 1} star ratings: ${val}`}
+                    position="top center"
+                    size="tiny"
+                    inverted
+                    trigger={
+                      <div
+                        className="rating-bar"
+                        key={"rating" + i}
+                        style={{
+                          height: percent * this.props.height + 1,
+                          width: this.props.width / chartData.length
+                        }}
+                      />
+                    }
                   />
                 );
               })}
             </div>
-            <div className="rating-label">
-              <span className="rating-average">{average}★</span>
-            </div>
+            {this.props.showAverage && (
+              <div className="rating-label">
+                <span className="rating-average">{average}</span>
+              </div>
+            )}
           </div>
         </React.Fragment>
       );

--- a/frontend/src/modules/profile/components/ratings/styles.css
+++ b/frontend/src/modules/profile/components/ratings/styles.css
@@ -1,36 +1,39 @@
 .rating-chart {
-    background-color: #14181c;
-    /* border: 2px solid white; */
-    margin: auto;
-    display: flex;
-    
+  background-color: #14181c;
+  margin: auto;
+  display: flex;
 }
 
-.rating-chart > .rating-bar{
-   background-color: #435566;
-   margin-top: auto;
-   border-top-right-radius: 3px;
-   border-top-left-radius: 3px;
-   border-right: 1px solid #14181c;
+.rating-chart > .rating-bar {
+  background-color: #435566;
+  margin-top: auto;
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  border-right: 1px solid #14181c;
 }
 
-.rating-chart > .rating-bar:hover{
-    background-color: #667788;
-    margin-top: auto
- }
+.rating-chart > .rating-bar:hover {
+  background-color: #667788;
+  margin-top: auto;
+}
 
- .rating{
-     display: flex;
- }
+.rating {
+  display: flex;
+}
+
 .rating-average {
-    margin-top: auto;
+  margin-top: auto;
+  font-size: 1.75rem;
+  font-family: "Lato", sans-serif;
+  font-weight: 300;
+  display: inline-block;
 }
 
-.rating-label{
-    margin-top: auto;
-
+.rating-label {
+  margin-top: auto;
 }
- .star {
-     color: green;
-     margin-top: auto;
- }
+
+.star {
+  color: green;
+  margin-top: auto;
+}

--- a/frontend/src/modules/profile/index.js
+++ b/frontend/src/modules/profile/index.js
@@ -184,8 +184,13 @@ class Profile extends Component {
                         <p className="profile-bio">{bio}</p>
                       </React.Fragment>
                     )}
-                    <Ratings user_id={me.id} height={75} width={250}/>
                     <Journal me={me} username={username} />
+                    <Ratings
+                      showAverage={false}
+                      userId={me.id}
+                      height={55}
+                      width={225}
+                    />
                     <Divider horizontal>Backlog</Divider>
                     {backlog.length > 0 ? (
                       <ListPreview games={backlog} />


### PR DESCRIPTION
Added popup, showAverage prop and made bars a bit smaller.

> ![Peek 2019-07-15 09-21](https://user-images.githubusercontent.com/11547406/61231922-f9c80b00-a6e1-11e9-9531-dca39dd824f0.gif)

The `showAverage` prop allows us to _not_ render the average in a user's profile, but to show it on a game's page in the future.

> ![image](https://user-images.githubusercontent.com/11547406/61232017-309e2100-a6e2-11e9-9e38-7cb35a6d86fd.png)
